### PR TITLE
Add bookmark storage functionality

### DIFF
--- a/src/components/BookmarkIcon/BookmarkIcon.jsx
+++ b/src/components/BookmarkIcon/BookmarkIcon.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { BsBookmark, BsBookmarkFill } from 'react-icons/bs';
+
+export const BookmarkIcon = ({ isFilled, onClick } = {}) => (
+  <div>
+    { isFilled
+      ? <BsBookmarkFill onClick={onClick} />
+      : <BsBookmark onClick={onClick} /> }
+  </div>
+);

--- a/src/components/DetailCard/DetailCard.jsx
+++ b/src/components/DetailCard/DetailCard.jsx
@@ -1,38 +1,46 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Segment, Placeholder } from 'semantic-ui-react';
 import { SegmentStyle } from './DetailCard.styles';
+import { BookmarkIcon } from '../BookmarkIcon/BookmarkIcon';
 
 // Hui Ying: I am not sure how the progress for DetailCard is coming along, but the api is returning the following 
 // fields as seen in the props received. I am commenting the prices for now.
 
 export const DetailCard = ({
-  link, images, title, location, tags, price, pax, description, facilities, promos
-} = {}) => (title ? (
+  link, images, title, location, tags, price, pax, description, facilities, promos, bookmarks, updateBookmarks
+} = {}) => {
+  let isBookmarked = false;
+  if (bookmarks) {
+    isBookmarked = bookmarks.includes(title);
+  }
 
-  <Segment style={SegmentStyle}>
-    <div className="ui items">
-      <div className="item">
-        <div className="image">
-          <img
-            src={images[0]}
-            alt="description of place"
-            width="200"
-            height="121"
-          />
-        </div>
-        <div className="content">
-          <div className="header">{title}</div>
-          <div className="meta">{location}</div>
-          <div className="description">{description}</div>
-          {/* {price.map((item) => (
-            <div className="ui label">{item}</div>
-          ))} */}
+  return (title ? (
+
+    <Segment style={SegmentStyle}>
+      <div className="ui items">
+        <div className="item">
+          <div className="image">
+            <img
+              src={images[0]}
+              alt="description of place"
+              width="200"
+              height="121"
+            />
+          </div>
+          <div className="content">
+            <div className="header">{title}</div>
+            <div className="meta">{location}</div>
+            <div className="description">{description}</div>
+            {/* {price.map((item) => (
+              <div className="ui label">{item}</div>
+            ))} */}
+            <BookmarkIcon isFilled={isBookmarked} onClick={() => updateBookmarks(title)} />
+          </div>
         </div>
       </div>
-    </div>
-  </Segment>
+    </Segment>
 
-) : (
+  ) : (
 
     <Segment style={SegmentStyle}>
       <div className="ui items">
@@ -54,3 +62,4 @@ export const DetailCard = ({
       </div>
     </Segment>
   ));
+};

--- a/src/pages/DetailsPage/DetailsPage.jsx
+++ b/src/pages/DetailsPage/DetailsPage.jsx
@@ -28,11 +28,33 @@ const Details = () => {
     fetchVenues();
   }, []);
 
+  // Bookmarks - stored as a list of title
+  // TODO: update to some form of unique identifier
+  const [bookmarks, setBookmarks] = React.useState(
+    JSON.parse(localStorage.getItem('bookmarks')) || []
+  );
+
+  const updateBookmarks = (title) => {
+    const index = bookmarks.indexOf(title);
+    let newBookmarks = bookmarks;
+    if (index > -1) {
+      // Remove from bookmark
+      newBookmarks = bookmarks.filter((value, idx) => index !== idx);
+    } else {
+      // Add to bookmark
+      newBookmarks = [...bookmarks, title];
+    }
+    setBookmarks(newBookmarks);
+    localStorage.setItem('bookmarks', JSON.stringify(newBookmarks));
+  };
+
   return (
     <PortalLayout pathname="/detail">
       <div>
         <div className="row" style={style.filterbarStyle}>
           TODO: Add in the filter components here
+          {/* For testing purposes to preview current bookmarks list */}
+          {bookmarks}
         </div>
         {loading && data.length === 0 ? (
           <div>
@@ -57,7 +79,7 @@ const Details = () => {
               <Grid centered stackable columns={2}>
                 <Grid.Column width={10}>
                   {data.map((result) => (
-                    <DetailCard {...result} />
+                    <DetailCard {...result} bookmarks={bookmarks} updateBookmarks={updateBookmarks} />
                   ))}
                 </Grid.Column>
                 <Grid.Column width={4}>


### PR DESCRIPTION
- Add bookmark storage functionality to the details page

TODO:
- Have a unique identifier (e.g. ID) for venues for bookmark storage. For now, I store the title but might face issues when there are 2 venues with the same title.
- Use same retrieving code to retrieve from bookmarks page @siyingpoof - `JSON.parse(localStorage.getItem('bookmarks'))`

Feel free to suggest modifications to the data structure. Right now, I think storing as a list of titles is fine.